### PR TITLE
Fixed build against rust nightly.

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -7,6 +7,8 @@
  */
 
 use std::{fmt, hash};
+use std::cmp::Ordering;
+use std::ops::{Add, Sub};
 
 use {Weekday, Datelike};
 use duration::Duration;
@@ -18,7 +20,7 @@ use datetime::DateTime;
 use format::DelayedFormat;
 
 /// ISO 8601 calendar date with timezone.
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct Date<Off> {
     date: NaiveDate,
     offset: Off,
@@ -289,6 +291,7 @@ impl<Off:Offset> fmt::Show for Date<Off> {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::IntoCow;
     use std::fmt;
     use std::str::SendStr;
 
@@ -301,7 +304,7 @@ mod tests {
     use datetime::DateTime;
     use offset::{Offset, LocalResult};
 
-    #[deriving(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, PartialEq, Eq)]
     struct UTC1y; // same to UTC but with an offset of 365 days
 
     impl Offset for UTC1y {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -7,6 +7,8 @@
  */
 
 use std::{fmt, hash};
+use std::cmp::Ordering;
+use std::ops::{Add, Sub};
 
 use {Weekday, Timelike, Datelike};
 use offset::Offset;
@@ -17,7 +19,7 @@ use date::Date;
 use format::DelayedFormat;
 
 /// ISO 8601 combined date and time with timezone.
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct DateTime<Off> {
     datetime: NaiveDateTime,
     offset: Off,

--- a/src/format.rs
+++ b/src/format.rs
@@ -8,7 +8,7 @@
 
 use std::fmt;
 use std::str::SendStr;
-use std::io::{IoResult, IoError, InvalidInput};
+//use std::io::{IoResult, IoError, InvalidInput};
 
 use {Datelike, Timelike};
 use duration::Duration;
@@ -17,16 +17,16 @@ use naive::date::NaiveDate;
 use naive::time::NaiveTime;
 
 /// The internal workhouse for `DelayedFormat`.
-fn format(w: &mut Writer, date: Option<&NaiveDate>, time: Option<&NaiveTime>,
-          off: Option<&(SendStr, Duration)>, fmt: &str) -> IoResult<()> {
-    static SHORT_MONTHS: [&'static str, ..12] =
+fn format(w: &mut fmt::Formatter, date: Option<&NaiveDate>, time: Option<&NaiveTime>,
+          off: Option<&(SendStr, Duration)>, fmt: &str) -> fmt::Result {
+    static SHORT_MONTHS: [&'static str; 12] =
         ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-    static LONG_MONTHS: [&'static str, ..12] =
+    static LONG_MONTHS: [&'static str; 12] =
         ["January", "February", "March", "April", "May", "June",
          "July", "August", "September", "October", "November", "December"];
-    static SHORT_WEEKDAYS: [&'static str, ..7] =
+    static SHORT_WEEKDAYS: [&'static str; 7] =
         ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-    static LONG_WEEKDAYS: [&'static str, ..7] =
+    static LONG_WEEKDAYS: [&'static str; 7] =
         ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
 
     let mut parts = fmt.split('%');
@@ -159,8 +159,9 @@ fn format(w: &mut Writer, date: Option<&NaiveDate>, time: Option<&NaiveTime>,
             (Some('n'), _, _, _) => try!(write!(w, "\n")),
 
             (Some(c), _, _, _) => {
-                return Err(IoError { kind: InvalidInput, desc: "invalid date/time format",
-                                     detail: Some(format!("unsupported escape sequence %{}", c)) });
+                return Err(fmt::Error);
+                // return Err(IoError { kind: InvalidInput, desc: "invalid date/time format",
+                //                      detail: Some(format!("unsupported escape sequence %{}", c)) });
             }
 
             (None, _, _, _) => {
@@ -174,8 +175,9 @@ fn format(w: &mut Writer, date: Option<&NaiveDate>, time: Option<&NaiveTime>,
     }
 
     if last_was_percent { // a stray `%`
-        Err(IoError { kind: InvalidInput,
-                      desc: "invalid date/time format: stray `%`", detail: None })
+        return Err(fmt::Error);
+        // Err(IoError { kind: InvalidInput,
+        //               desc: "invalid date/time format: stray `%`", detail: None })
     } else {
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ Advanced offset handling and date/time parsing is not yet supported (but is plan
 #![doc(html_root_url = "https://lifthrasiir.github.io/rust-chrono/")]
 
 #![feature(macro_rules, associated_types, default_type_params)]
+#![feature(old_orphan_check)]  // TODO: Remove this when derive(Hash) no longer needs it.
 #![deny(missing_docs)]
 
 extern crate "time" as stdtime;
@@ -226,7 +227,7 @@ pub mod format;
 ///
 /// The order of the days of week depends on the context.
 /// One should prefer `*_from_monday` or `*_from_sunday` methods to get the correct result.
-#[deriving(PartialEq, Eq, Copy, Clone, FromPrimitive, Show)]
+#[derive(PartialEq, Eq, Copy, Clone, FromPrimitive, Show)]
 pub enum Weekday {
     /// Monday.
     Mon = 0,

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -7,7 +7,8 @@
  */
 
 use std::fmt;
-use std::num::Int;
+use std::num::{Int, ToPrimitive};
+use std::ops::{Add, Sub};
 
 use {Weekday, Datelike};
 use div::div_mod_floor;
@@ -24,7 +25,7 @@ const MIN_YEAR: i32 = internals::MIN_YEAR as i32;
 /// ISO 8601 calendar date without timezone.
 /// Allows for every proleptic Gregorian date from Jan 1, 262145 BCE to Dec 31, 262143 CE.
 /// Also supports the conversion from ISO 8601 ordinal and week date.
-#[deriving(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct NaiveDate {
     ymdf: DateImpl, // (year << 13) | of
 }
@@ -799,7 +800,7 @@ mod internals {
     /// where `a` is `1` for the common year (simplifies the `Of` validation)
     /// and `bbb` is a non-zero `Weekday` (mapping `Mon` to 7) of the last day in the past year
     /// (simplifies the day of week calculation from the 1-based ordinal).
-    #[deriving(PartialEq, Eq, Copy)]
+    #[derive(PartialEq, Eq, Copy)]
     pub struct YearFlags(pub u8);
 
     pub const A: YearFlags = YearFlags(0o15); pub const AG: YearFlags = YearFlags(0o05);
@@ -810,7 +811,7 @@ mod internals {
     pub const F: YearFlags = YearFlags(0o17); pub const FE: YearFlags = YearFlags(0o07);
     pub const G: YearFlags = YearFlags(0o16); pub const GF: YearFlags = YearFlags(0o06);
 
-    static YEAR_TO_FLAGS: [YearFlags, ..400] = [
+    static YEAR_TO_FLAGS: [YearFlags; 400] = [
         BA, G, F, E, DC, B, A, G, FE, D, C, B, AG, F, E, D, CB, A, G, F,
         ED, C, B, A, GF, E, D, C, BA, G, F, E, DC, B, A, G, FE, D, C, B,
         AG, F, E, D, CB, A, G, F, ED, C, B, A, GF, E, D, C, BA, G, F, E,
@@ -833,7 +834,7 @@ mod internals {
         FE, D, C, B, AG, F, E, D, CB, A, G, F, ED, C, B, A, GF, E, D, C, // 400
     ];
 
-    static YEAR_DELTAS: [u8, ..401] = [
+    static YEAR_DELTAS: [u8; 401] = [
          0,  1,  1,  1,  1,  2,  2,  2,  2,  3,  3,  3,  3,  4,  4,  4,  4,  5,  5,  5,
          5,  6,  6,  6,  6,  7,  7,  7,  7,  8,  8,  8,  8,  9,  9,  9,  9, 10, 10, 10,
         10, 11, 11, 11, 11, 12, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 14, 15, 15, 15,
@@ -928,7 +929,7 @@ mod internals {
     pub const MAX_MDL: u32 = (12 << 6) | (31 << 1) | 1;
 
     const XX: i8 = -128;
-    static MDL_TO_OL: [i8, ..(MAX_MDL as uint + 1u)] = [
+    static MDL_TO_OL: [i8; (MAX_MDL as uint + 1u)] = [
          XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX,
          XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX,
          XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX,
@@ -983,7 +984,7 @@ mod internals {
          98,100, 98,100, 98,100, 98,100, 98,100, 98,100, 98,100, 98,100, // 12
     ];
 
-    static OL_TO_MDL: [u8, ..(MAX_OL as uint + 1u)] = [
+    static OL_TO_MDL: [u8; (MAX_OL as uint + 1u)] = [
           0,  0,                                                         // 0
          64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
          64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -1039,7 +1040,7 @@ mod internals {
     ///
     /// The whole bits except for the least 3 bits are referred as `Ol` (ordinal and leap flag),
     /// which is an index to the `OL_TO_MDL` lookup table.
-    #[deriving(PartialEq, PartialOrd, Copy)]
+    #[derive(PartialEq, PartialOrd, Copy)]
     pub struct Of(pub u32);
 
     impl Of {
@@ -1140,7 +1141,7 @@ mod internals {
     /// The whole bits except for the least 3 bits are referred as `Mdl`
     /// (month, day of month and leap flag),
     /// which is an index to the `MDL_TO_OL` lookup table.
-    #[deriving(PartialEq, PartialOrd, Copy)]
+    #[derive(PartialEq, PartialOrd, Copy)]
     pub struct Mdf(pub u32);
 
     impl Mdf {
@@ -1242,9 +1243,9 @@ mod internals {
         use std::iter::range_inclusive;
         use std::u32;
 
-        const NONLEAP_FLAGS: [YearFlags, ..7] = [A, B, C, D, E, F, G];
-        const LEAP_FLAGS: [YearFlags, ..7] = [AG, BA, CB, DC, ED, FE, GF];
-        const FLAGS: [YearFlags, ..14] = [A, B, C, D, E, F, G, AG, BA, CB, DC, ED, FE, GF];
+        const NONLEAP_FLAGS: [YearFlags; 7] = [A, B, C, D, E, F, G];
+        const LEAP_FLAGS: [YearFlags; 7] = [AG, BA, CB, DC, ED, FE, GF];
+        const FLAGS: [YearFlags; 14] = [A, B, C, D, E, F, G, AG, BA, CB, DC, ED, FE, GF];
 
         #[test]
         fn test_year_flags_ndays_from_year() {

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -7,7 +7,8 @@
  */
 
 use std::fmt;
-use std::num::Int;
+use std::num::{Int, ToPrimitive};
+use std::ops::{Add, Sub};
 
 use {Weekday, Timelike, Datelike};
 use div::div_mod_floor;
@@ -17,7 +18,7 @@ use naive::date::NaiveDate;
 use format::DelayedFormat;
 
 /// ISO 8601 combined date and time without timezone.
-#[deriving(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct NaiveDateTime {
     date: NaiveDate,
     time: NaiveTime,

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 use std::num::Int;
+use std::ops::{Add, Sub};
 
 use Timelike;
 use div::div_mod_floor;
@@ -17,7 +18,7 @@ use format::DelayedFormat;
 
 /// ISO 8601 time without timezone.
 /// Allows for the nanosecond precision and optional leap second representation.
-#[deriving(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub struct NaiveTime {
     secs: u32,
     frac: u32,

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -6,6 +6,7 @@
  * Offsets from the local time to UTC.
  */
 
+use std::borrow::IntoCow;
 use std::fmt;
 use std::str::SendStr;
 use stdtime;
@@ -21,7 +22,7 @@ use time::Time;
 use datetime::DateTime;
 
 /// The conversion result from the local time to the timezone-aware datetime types.
-#[deriving(Clone, PartialEq, Show)]
+#[derive(Clone, PartialEq, Show)]
 pub enum LocalResult<T> {
     /// Given local time representation is invalid.
     /// This can occur when, for example, the positive timezone transition.
@@ -321,7 +322,7 @@ pub trait Offset: Clone + fmt::Show {
 }
 
 /// The UTC timescale. This is the most efficient offset when you don't need the local time.
-#[deriving(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct UTC;
 
 impl UTC {
@@ -360,7 +361,7 @@ impl fmt::Show for UTC {
 }
 
 /// The fixed offset, from UTC-23:59:59 to UTC+23:59:59.
-#[deriving(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct FixedOffset {
     local_minus_utc: i32,
 }
@@ -451,7 +452,7 @@ impl fmt::Show for FixedOffset {
 }
 
 /// The local timescale. This is implemented via the standard `time` crate.
-#[deriving(Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct Local {
     cached: FixedOffset,
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -7,6 +7,8 @@
  */
 
 use std::{fmt, hash};
+use std::cmp::Ordering;
+use std::ops::{Add, Sub};
 
 use Timelike;
 use offset::Offset;
@@ -15,7 +17,7 @@ use naive::time::NaiveTime;
 use format::DelayedFormat;
 
 /// ISO 8601 time with timezone.
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct Time<Off> {
     time: NaiveTime,
     offset: Off,


### PR DESCRIPTION
Added `use` statements for `cmp::Ordering`, `ops::{Add, Sub}`, `borrow::IntoCow`, `num::ToPrimitive`

Changed `deriving` -> `derive`. Changed `[x, ..N]` -> `[x; N]`.

Made `format(f: &fmt::Formatter)` return `fmt::Result` instead of
`IoResult`. Had to raise generic errors in a couple of cases where
`IoResult`'s fields were being set (but these errors were being thrown
out anyway).

Temporarily set `#![feature(old_orphan_check)]` because `#[deriving(Hash)]` needs it (see https://github.com/rust-lang/rust/issues/20477).

Thanks to @eddyb for explaining the format() situation.