### PR TITLE
Fix building against latest rust nightly - rustc version ad9e75938

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -7,7 +7,7 @@
  */
 
 use std::fmt;
-use std::str::SendStr;
+use std::string::CowString;
 
 use {Datelike, Timelike};
 use duration::Duration;
@@ -17,7 +17,7 @@ use naive::time::NaiveTime;
 
 /// The internal workhouse for `DelayedFormat`.
 fn format(w: &mut fmt::Formatter, date: Option<&NaiveDate>, time: Option<&NaiveTime>,
-          off: Option<&(SendStr, Duration)>, fmt: &str) -> fmt::Result {
+          off: Option<&(CowString<'static>, Duration)>, fmt: &str) -> fmt::Result {
     static SHORT_MONTHS: [&'static str; 12] =
         ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
     static LONG_MONTHS: [&'static str; 12] =
@@ -186,7 +186,7 @@ pub struct DelayedFormat<'a> {
     /// The time view, if any.
     time: Option<NaiveTime>,
     /// The name and local-to-UTC difference for the offset (timezone), if any.
-    off: Option<(SendStr, Duration)>,
+    off: Option<(CowString<'static>, Duration)>,
     /// The format string.
     fmt: &'a str,
 }

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -8,7 +8,7 @@
 
 use std::borrow::IntoCow;
 use std::fmt;
-use std::str::SendStr;
+use std::string::CowString;
 use stdtime;
 
 use {Weekday, Datelike, Timelike};
@@ -294,7 +294,7 @@ pub trait Offset: Clone + fmt::Show {
     }
 
     /// Returns a name or abbreviation of this offset.
-    fn name(&self) -> SendStr;
+    fn name(&self) -> CowString<'static>;
 
     /// Returns the *current* offset from UTC to the local time.
     fn local_minus_utc(&self) -> Duration;
@@ -338,7 +338,7 @@ impl UTC {
 }
 
 impl Offset for UTC {
-    fn name(&self) -> SendStr { "UTC".into_cow() }
+    fn name(&self) -> CowString<'static> { "UTC".into_cow() }
     fn local_minus_utc(&self) -> Duration { Duration::zero() }
 
     fn from_local_date(&self, local: &NaiveDate) -> LocalResult<Date<UTC>> {
@@ -409,7 +409,7 @@ impl FixedOffset {
 }
 
 impl Offset for FixedOffset {
-    fn name(&self) -> SendStr { "UTC".into_cow() } // XXX
+    fn name(&self) -> CowString<'static> { "UTC".into_cow() } // XXX
     fn local_minus_utc(&self) -> Duration { Duration::seconds(self.local_minus_utc as i64) }
 
     fn from_local_date(&self, local: &NaiveDate) -> LocalResult<Date<FixedOffset>> {
@@ -505,7 +505,7 @@ impl Local {
 }
 
 impl Offset for Local {
-    fn name(&self) -> SendStr { "LMT".into_cow() } // XXX XXX
+    fn name(&self) -> CowString<'static> { "LMT".into_cow() } // XXX XXX
     fn local_minus_utc(&self) -> Duration { self.cached.local_minus_utc() }
 
     fn from_local_date(&self, local: &NaiveDate) -> LocalResult<Date<Local>> {


### PR DESCRIPTION
Updates all usages of SendStr to CowString<'static>.