### PR TITLE
Add optional rustc-serialize support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ env:
     - secure: i8Ijk6g4/26e3e7+r2OeGAPSP8G8O9P50JibW1omJ0j0ixXhyhPoY2bch3CGhnOu44dI5O31IIbjJJ+iEMp29xQBvkv9YpxAI+hIzOP+XAH6GCYxUDiBVcDoWrXTj+wU6/veuvjLCunu4eRHlskrgJbZXhUVODYzJuLgsN8Ou0w=
 script:
   - cargo build -v
+  - cargo build -v --features rustc-serialize
   - cargo test -v
+  - cargo test -v --features rustc-serialize
   - cargo doc
 after_script:
   - cd target && curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ name = "chrono"
 [dependencies]
 time = "*"
 num = "*"
+rustc-serialize = { version = "0.3", optional = true }

--- a/src/date.rs
+++ b/src/date.rs
@@ -22,6 +22,7 @@ use format::{Item, DelayedFormat, StrftimeItems};
 
 /// ISO 8601 calendar date with time zone.
 #[derive(Clone)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Date<Tz: TimeZone> {
     date: NaiveDate,
     offset: Tz::Offset,

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -24,6 +24,7 @@ use format::{parse, Parsed, ParseError, ParseResult, DelayedFormat, StrftimeItem
 
 /// ISO 8601 combined date and time with time zone.
 #[derive(Clone)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct DateTime<Tz: TimeZone> {
     datetime: NaiveDateTime,
     offset: Tz::Offset,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,8 @@ Advanced time zone handling is not yet supported (but is planned in 0.3).
 
 extern crate time as stdtime;
 extern crate num;
+#[cfg(feature = "rustc-serialize")]
+extern crate rustc_serialize;
 
 pub use duration::Duration;
 pub use offset::{TimeZone, Offset, LocalResult};
@@ -316,6 +318,7 @@ pub mod format;
 /// The order of the days of week depends on the context.
 /// One should prefer `*_from_monday` or `*_from_sunday` methods to get the correct result.
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub enum Weekday {
     /// Monday.
     Mon = 0,

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -49,6 +49,7 @@ const MIN_DAYS_FROM_YEAR_0: i32 = (MIN_YEAR + 400_000) * 365 +
 /// Allows for every proleptic Gregorian date from Jan 1, 262145 BCE to Dec 31, 262143 CE.
 /// Also supports the conversion from ISO 8601 ordinal and week date.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct NaiveDate {
     ymdf: DateImpl, // (year << 13) | of
 }
@@ -1056,6 +1057,7 @@ mod internals {
     /// and `bbb` is a non-zero `Weekday` (mapping `Mon` to 7) of the last day in the past year
     /// (simplifies the day of week calculation from the 1-based ordinal).
     #[derive(PartialEq, Eq, Copy, Clone)]
+    #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
     pub struct YearFlags(pub u8);
 
     pub const A: YearFlags = YearFlags(0o15); pub const AG: YearFlags = YearFlags(0o05);
@@ -1296,6 +1298,7 @@ mod internals {
     /// The whole bits except for the least 3 bits are referred as `Ol` (ordinal and leap flag),
     /// which is an index to the `OL_TO_MDL` lookup table.
     #[derive(PartialEq, PartialOrd, Copy, Clone)]
+    #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
     pub struct Of(pub u32);
 
     impl Of {
@@ -1397,6 +1400,7 @@ mod internals {
     /// (month, day of month and leap flag),
     /// which is an index to the `MDL_TO_OL` lookup table.
     #[derive(PartialEq, PartialOrd, Copy, Clone)]
+    #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
     pub struct Mdf(pub u32);
 
     impl Mdf {

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -20,6 +20,7 @@ use format::{parse, Parsed, ParseError, ParseResult, DelayedFormat, StrftimeItem
 
 /// ISO 8601 combined date and time without timezone.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct NaiveDateTime {
     date: NaiveDate,
     time: NaiveTime,

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -18,6 +18,7 @@ use format::{parse, Parsed, ParseError, ParseResult, DelayedFormat, StrftimeItem
 /// ISO 8601 time without timezone.
 /// Allows for the nanosecond precision and optional leap second representation.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct NaiveTime {
     secs: u32,
     frac: u32,

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -16,6 +16,7 @@ use super::{TimeZone, Offset, LocalResult};
 
 /// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
 #[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct FixedOffset {
     local_minus_utc: i32,
 }

--- a/src/offset/local.rs
+++ b/src/offset/local.rs
@@ -59,6 +59,7 @@ fn datetime_to_timespec(d: &NaiveDateTime, local: bool) -> stdtime::Timespec {
 
 /// The local timescale. This is implemented via the standard `time` crate.
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Local;
 
 impl Local {

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -19,6 +19,7 @@ use super::{TimeZone, Offset, LocalResult};
 /// The UTC time zone. This is the most efficient time zone when you don't need the local time.
 /// It is also used as an offset (which is also a dummy type).
 #[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct UTC;
 
 impl UTC {


### PR DESCRIPTION
This PR support deriving `rustc-serialize` traits when `rustc-serialize` feature is enabled, as the same way as implemented in `time`.

Temporary or format-related structs and enums are excluded.