### PR TITLE
Fix nightly warnings related to lifetimes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,7 +457,7 @@ impl num::traits::FromPrimitive for Weekday {
 
 
 /// The common set of methods for date component.
-pub trait Datelike {
+pub trait Datelike: Sized {
     /// Returns the year number.
     fn year(&self) -> i32;
 
@@ -550,7 +550,7 @@ pub trait Datelike {
 }
 
 /// The common set of methods for time component.
-pub trait Timelike {
+pub trait Timelike: Sized {
     /// Returns the hour number from 0 to 23.
     fn hour(&self) -> u32;
 


### PR DESCRIPTION
The following warnings appear:

```
   Compiling chrono v0.2.15 (file:///Users/coreyf/Development/rust/rust-chrono)
src/lib.rs:504:5: 504:52 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:504     fn with_year(&self, year: i32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:504:5: 504:52 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:504:5: 504:52 note: `Self` does not have a constant size known at compile-time
src/lib.rs:504     fn with_year(&self, year: i32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:504:5: 504:52 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:504     fn with_year(&self, year: i32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:504:5: 504:52 note: required by `core::option::Option`
src/lib.rs:504     fn with_year(&self, year: i32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:509:5: 509:54 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:509     fn with_month(&self, month: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:509:5: 509:54 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:509:5: 509:54 note: `Self` does not have a constant size known at compile-time
src/lib.rs:509     fn with_month(&self, month: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:509:5: 509:54 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:509     fn with_month(&self, month: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:509:5: 509:54 note: required by `core::option::Option`
src/lib.rs:509     fn with_month(&self, month: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:514:5: 514:56 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:514     fn with_month0(&self, month0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:514:5: 514:56 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:514:5: 514:56 note: `Self` does not have a constant size known at compile-time
src/lib.rs:514     fn with_month0(&self, month0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:514:5: 514:56 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:514     fn with_month0(&self, month0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:514:5: 514:56 note: required by `core::option::Option`
src/lib.rs:514     fn with_month0(&self, month0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:519:5: 519:50 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:519     fn with_day(&self, day: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:519:5: 519:50 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:519:5: 519:50 note: `Self` does not have a constant size known at compile-time
src/lib.rs:519     fn with_day(&self, day: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:519:5: 519:50 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:519     fn with_day(&self, day: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:519:5: 519:50 note: required by `core::option::Option`
src/lib.rs:519     fn with_day(&self, day: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:524:5: 524:52 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:524     fn with_day0(&self, day0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:524:5: 524:52 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:524:5: 524:52 note: `Self` does not have a constant size known at compile-time
src/lib.rs:524     fn with_day0(&self, day0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:524:5: 524:52 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:524     fn with_day0(&self, day0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:524:5: 524:52 note: required by `core::option::Option`
src/lib.rs:524     fn with_day0(&self, day0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:529:5: 529:58 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:529     fn with_ordinal(&self, ordinal: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:529:5: 529:58 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:529:5: 529:58 note: `Self` does not have a constant size known at compile-time
src/lib.rs:529     fn with_ordinal(&self, ordinal: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:529:5: 529:58 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:529     fn with_ordinal(&self, ordinal: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:529:5: 529:58 note: required by `core::option::Option`
src/lib.rs:529     fn with_ordinal(&self, ordinal: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:534:5: 534:60 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:534     fn with_ordinal0(&self, ordinal0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:534:5: 534:60 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:534:5: 534:60 note: `Self` does not have a constant size known at compile-time
src/lib.rs:534     fn with_ordinal0(&self, ordinal0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:534:5: 534:60 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:534     fn with_ordinal0(&self, ordinal0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:534:5: 534:60 note: required by `core::option::Option`
src/lib.rs:534     fn with_ordinal0(&self, ordinal0: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:580:5: 580:52 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:580     fn with_hour(&self, hour: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:580:5: 580:52 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:580:5: 580:52 note: `Self` does not have a constant size known at compile-time
src/lib.rs:580     fn with_hour(&self, hour: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:580:5: 580:52 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:580     fn with_hour(&self, hour: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:580:5: 580:52 note: required by `core::option::Option`
src/lib.rs:580     fn with_hour(&self, hour: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:585:5: 585:53 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:585     fn with_minute(&self, min: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:585:5: 585:53 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:585:5: 585:53 note: `Self` does not have a constant size known at compile-time
src/lib.rs:585     fn with_minute(&self, min: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:585:5: 585:53 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:585     fn with_minute(&self, min: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:585:5: 585:53 note: required by `core::option::Option`
src/lib.rs:585     fn with_minute(&self, min: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:590:5: 590:53 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:590     fn with_second(&self, sec: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:590:5: 590:53 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:590:5: 590:53 note: `Self` does not have a constant size known at compile-time
src/lib.rs:590     fn with_second(&self, sec: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:590:5: 590:53 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:590     fn with_second(&self, sec: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:590:5: 590:53 note: required by `core::option::Option`
src/lib.rs:590     fn with_second(&self, sec: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:595:5: 595:58 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:595     fn with_nanosecond(&self, nano: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:595:5: 595:58 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:595:5: 595:58 note: `Self` does not have a constant size known at compile-time
src/lib.rs:595     fn with_nanosecond(&self, nano: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:595:5: 595:58 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:595     fn with_nanosecond(&self, nano: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:595:5: 595:58 note: required by `core::option::Option`
src/lib.rs:595     fn with_nanosecond(&self, nano: u32) -> Option<Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

...because of:

https://github.com/rust-lang/rfcs/pull/1214