### PR TITLE
Add serde serialization support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ env:
 script:
   - cargo build -v
   - cargo build -v --features rustc-serialize
+  - cargo build -v --features serde_support
   - cargo test -v
   - cargo test -v --features rustc-serialize
+  - cargo test -v --features serde_support
   - cargo doc
 after_script:
   - cd target && curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: rust
 rust:
     - stable
     - nightly
@@ -11,10 +12,12 @@ env:
 script:
   - cargo build -v
   - cargo build -v --features rustc-serialize
-  - [ "$TRAVIS_RUST_VERSION" = "nightly" ] && cargo build -v --features serde_support
   - cargo test -v
   - cargo test -v --features rustc-serialize
-  - [ "$TRAVIS_RUST_VERSION" = "nightly" ] && cargo test -v --features serde_support
+  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+      cargo build -v --features serde_support;
+      cargo test -v --features serde_support;
+    fi
   - cargo doc
 after_script:
   - cd target && curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: rust
+rust:
+    - stable
+    - nightly
 os:
   - linux
   - osx
@@ -9,10 +11,10 @@ env:
 script:
   - cargo build -v
   - cargo build -v --features rustc-serialize
-  - cargo build -v --features serde_support
+  - [ "$TRAVIS_RUST_VERSION" = "nightly" ] && cargo build -v --features serde_support
   - cargo test -v
   - cargo test -v --features rustc-serialize
-  - cargo test -v --features serde_support
+  - [ "$TRAVIS_RUST_VERSION" = "nightly" ] && cargo test -v --features serde_support
   - cargo doc
 after_script:
   - cd target && curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ version = "*"
 optional = true
 
 [dev-dependencies]
-bincode = "*"
+bincode = { version = "*", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ keywords = ["date", "time", "calendar"]
 readme = "README.md"
 license = "MIT/Apache-2.0"
 
+[features]
+default = []
+
+serde_support = ["serde", "serde_macros"]
+
 [lib]
 name = "chrono"
 
@@ -19,3 +24,11 @@ time = "*"
 num = "*"
 rustc-serialize = { version = "0.3", optional = true }
 
+[dependencies.serde]
+version = "0.5"
+optional = true
+features = ["nightly"]
+
+[dependencies.serde_macros]
+version = "*"
+optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ features = ["nightly"]
 [dependencies.serde_macros]
 version = "*"
 optional = true
+
+[dev-dependencies]
+bincode = "*"

--- a/src/date.rs
+++ b/src/date.rs
@@ -407,4 +407,24 @@ mod tests {
     fn test_local_date_sanity_check() { // issue #27
         assert_eq!(Local.ymd(2999, 12, 28).day(), 28);
     }
+
+    #[cfg(feature = "serde_support")] extern crate bincode;
+    #[cfg(feature = "serde_support")] use self::bincode::serde::{serialize, serialized_size, deserialize, DeserializeResult};
+    #[cfg(feature = "serde_support")] use self::bincode::SizeLimit::{Bounded};
+
+    #[cfg(feature = "serde_support")]
+    #[test]
+    fn test_serde() {
+
+        let d: ::Date<::UTC> = ::UTC.ymd(2014, 7, 8);
+        let size = serialized_size(&d);
+        let serialized = serialize(&d, Bounded(size));
+        assert!(serialized.is_ok());
+
+        let deserialized: DeserializeResult<::Date<::UTC>> = deserialize(&serialized.unwrap());
+        assert!(deserialized.is_ok());
+
+        let deserialized = deserialized.unwrap();
+        assert_eq!(format!("{:?}", deserialized), "2014-07-08Z".to_string());
+    }
 }

--- a/src/date.rs
+++ b/src/date.rs
@@ -23,6 +23,7 @@ use format::{Item, DelayedFormat, StrftimeItems};
 /// ISO 8601 calendar date with time zone.
 #[derive(Clone)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Date<Tz: TimeZone> {
     date: NaiveDate,
     offset: Tz::Offset,
@@ -363,6 +364,7 @@ mod tests {
     struct UTC1y; // same to UTC but with an offset of 365 days
 
     #[derive(Copy, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
     struct OneYear;
 
     impl TimeZone for UTC1y {
@@ -406,4 +408,3 @@ mod tests {
         assert_eq!(Local.ymd(2999, 12, 28).day(), 28);
     }
 }
-

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -25,6 +25,7 @@ use format::{parse, Parsed, ParseError, ParseResult, DelayedFormat, StrftimeItem
 /// ISO 8601 combined date and time with time zone.
 #[derive(Clone)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct DateTime<Tz: TimeZone> {
     datetime: NaiveDateTime,
     offset: Tz::Offset,
@@ -519,4 +520,3 @@ mod tests {
         }).join().unwrap();
     }
 }
-

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -519,4 +519,24 @@ mod tests {
             let _ = a;
         }).join().unwrap();
     }
+
+    #[cfg(feature = "serde_support")] extern crate bincode;
+    #[cfg(feature = "serde_support")] use self::bincode::serde::{serialize, serialized_size, deserialize, DeserializeResult};
+    #[cfg(feature = "serde_support")] use self::bincode::SizeLimit::{Bounded};
+
+    #[cfg(feature = "serde_support")]
+    #[test]
+    fn test_serde() {
+
+        let d: ::DateTime<::UTC> = ::UTC.ymd(2014, 7, 8).and_hms(9, 10, 11);
+        let size = serialized_size(&d);
+        let serialized = serialize(&d, Bounded(size));
+        assert!(serialized.is_ok());
+
+        let deserialized: DeserializeResult<::DateTime<::UTC>> = deserialize(&serialized.unwrap());
+        assert!(deserialized.is_ok());
+
+        let deserialized = deserialized.unwrap();
+        assert_eq!(format!("{:?}", deserialized), "2014-07-08T09:10:11Z".to_string());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,12 +269,18 @@ Advanced time zone handling is not yet supported (but is planned in 0.3).
 #![doc(html_root_url = "https://lifthrasiir.github.io/rust-chrono/")]
 
 #![cfg_attr(bench, feature(test))] // lib stability features as per RFC #507
+#![cfg_attr(feature = "serde_support", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "serde_support", plugin(serde_macros))]
+
 #![deny(missing_docs)]
 
 extern crate time as stdtime;
 extern crate num;
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
+
+#[cfg(feature = "serde_support")]
+extern crate serde;
 
 pub use duration::Duration;
 pub use offset::{TimeZone, Offset, LocalResult};
@@ -321,6 +327,7 @@ pub mod format;
 /// One should prefer `*_from_monday` or `*_from_sunday` methods to get the correct result.
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub enum Weekday {
     /// Monday.
     Mon = 0,

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -50,6 +50,7 @@ const MIN_DAYS_FROM_YEAR_0: i32 = (MIN_YEAR + 400_000) * 365 +
 /// Also supports the conversion from ISO 8601 ordinal and week date.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct NaiveDate {
     ymdf: DateImpl, // (year << 13) | of
 }
@@ -1485,6 +1486,7 @@ mod internals {
     /// (simplifies the day of week calculation from the 1-based ordinal).
     #[derive(PartialEq, Eq, Copy, Clone)]
     #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+    #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
     pub struct YearFlags(pub u8);
 
     pub const A: YearFlags = YearFlags(0o15); pub const AG: YearFlags = YearFlags(0o05);
@@ -1726,6 +1728,7 @@ mod internals {
     /// which is an index to the `OL_TO_MDL` lookup table.
     #[derive(PartialEq, PartialOrd, Copy, Clone)]
     #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+    #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
     pub struct Of(pub u32);
 
     impl Of {
@@ -1828,6 +1831,7 @@ mod internals {
     /// which is an index to the `MDL_TO_OL` lookup table.
     #[derive(PartialEq, PartialOrd, Copy, Clone)]
     #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+    #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
     pub struct Mdf(pub u32);
 
     impl Mdf {
@@ -2228,4 +2232,3 @@ mod internals {
         }
     }
 }
-

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1448,6 +1448,36 @@ mod tests {
         assert_eq!(NaiveDate::from_ymd(2010, 1, 3).format("%G,%g,%U,%W,%V").to_string(),
                    "2009,09,01,00,53");
     }
+
+    #[cfg(feature = "serde_support")] extern crate bincode;
+    #[cfg(feature = "serde_support")] use self::bincode::serde::{serialize, serialized_size, deserialize, DeserializeResult};
+    #[cfg(feature = "serde_support")] use self::bincode::SizeLimit::{Bounded};
+
+    #[cfg(feature = "serde_support")]
+    #[test]
+    fn test_serde() {
+
+        let d = NaiveDate::from_ymd(2012, 3, 4);
+        let size = serialized_size(&d);
+        let serialized = serialize(&d, Bounded(size));
+        assert!(serialized.is_ok());
+
+        let deserialized: DeserializeResult<NaiveDate> = deserialize(&serialized.unwrap());
+        assert!(deserialized.is_ok());
+
+        let deserialized = deserialized.unwrap();
+
+        assert_eq!(deserialized.format("%Y,%C,%y,%G,%g").to_string(), "2012,20,12,2012,12");
+        assert_eq!(deserialized.format("%m,%b,%h,%B").to_string(), "03,Mar,Mar,March");
+        assert_eq!(deserialized.format("%d,%e").to_string(), "04, 4");
+        assert_eq!(deserialized.format("%U,%W,%V").to_string(), "10,09,09");
+        assert_eq!(deserialized.format("%a,%A,%w,%u").to_string(), "Sun,Sunday,0,7");
+        assert_eq!(deserialized.format("%j").to_string(), "064"); // since 2012 is a leap year
+        assert_eq!(deserialized.format("%D,%x").to_string(), "03/04/12,03/04/12");
+        assert_eq!(deserialized.format("%F").to_string(), "2012-03-04");
+        assert_eq!(deserialized.format("%v").to_string(), " 4-Mar-2012");
+        assert_eq!(deserialized.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
+    }
 }
 
 /**
@@ -1486,7 +1516,6 @@ mod internals {
     /// (simplifies the day of week calculation from the 1-based ordinal).
     #[derive(PartialEq, Eq, Copy, Clone)]
     #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
-    #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
     pub struct YearFlags(pub u8);
 
     pub const A: YearFlags = YearFlags(0o15); pub const AG: YearFlags = YearFlags(0o05);

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -21,6 +21,7 @@ use format::{parse, Parsed, ParseError, ParseResult, DelayedFormat, StrftimeItem
 /// ISO 8601 combined date and time without timezone.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct NaiveDateTime {
     date: NaiveDate,
     time: NaiveTime,
@@ -469,4 +470,3 @@ mod tests {
         assert_eq!(t, (time - base).num_microseconds().unwrap());
     }
 }
-

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -485,4 +485,54 @@ mod tests {
         assert_eq!(NaiveTime::from_hms_milli(23, 59, 59, 1_000).format("%X").to_string(),
                    "23:59:60");
     }
+
+    #[cfg(feature = "serde_support")] extern crate bincode;
+    #[cfg(feature = "serde_support")] use self::bincode::serde::{serialize, serialized_size, deserialize, DeserializeResult};
+    #[cfg(feature = "serde_support")] use self::bincode::SizeLimit::{Bounded};
+
+    #[cfg(feature = "serde_support")]
+    #[test]
+    fn test_serde() {
+
+        let t = NaiveTime::from_hms_nano(3, 5, 7, 98765432);
+        let size = serialized_size(&t);
+        let serialized = serialize(&t, Bounded(size));
+        assert!(serialized.is_ok());
+
+        let deserialized: DeserializeResult<NaiveTime> = deserialize(&serialized.unwrap());
+        assert!(deserialized.is_ok());
+
+        let deserialized = deserialized.unwrap();
+        assert_eq!(deserialized.format("%H,%k,%I,%l,%P,%p").to_string(), "03, 3,03, 3,am,AM");
+        assert_eq!(deserialized.format("%M").to_string(), "05");
+        assert_eq!(deserialized.format("%S,%f").to_string(), "07,098765432");
+        assert_eq!(deserialized.format("%R").to_string(), "03:05");
+        assert_eq!(deserialized.format("%T,%X").to_string(), "03:05:07,03:05:07");
+        assert_eq!(deserialized.format("%r").to_string(), "03:05:07 AM");
+        assert_eq!(deserialized.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
+
+
+        let t = NaiveTime::from_hms(13, 57, 9);
+        let size = serialized_size(&t);
+        let serialized = serialize(&t, Bounded(size));
+        assert!(serialized.is_ok());
+
+        let deserialized: DeserializeResult<NaiveTime> = deserialize(&serialized.unwrap());
+        assert!(deserialized.is_ok());
+
+        let deserialized = deserialized.unwrap();
+        assert_eq!(deserialized.format("%r").to_string(), "01:57:09 PM");
+
+
+        let t = NaiveTime::from_hms_milli(23, 59, 59, 1_000);
+        let size = serialized_size(&t);
+        let serialized = serialize(&t, Bounded(size));
+        assert!(serialized.is_ok());
+
+        let deserialized: DeserializeResult<NaiveTime> = deserialize(&serialized.unwrap());
+        assert!(deserialized.is_ok());
+
+        let deserialized = deserialized.unwrap();
+        assert_eq!(deserialized.format("%X").to_string(), "23:59:60");
+    }
 }

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -19,6 +19,7 @@ use format::{parse, Parsed, ParseError, ParseResult, DelayedFormat, StrftimeItem
 /// Allows for the nanosecond precision and optional leap second representation.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct NaiveTime {
     secs: u32,
     frac: u32,
@@ -485,4 +486,3 @@ mod tests {
                    "23:59:60");
     }
 }
-

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -17,6 +17,7 @@ use super::{TimeZone, Offset, LocalResult};
 /// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct FixedOffset {
     local_minus_utc: i32,
 }
@@ -100,4 +101,3 @@ impl fmt::Debug for FixedOffset {
 impl fmt::Display for FixedOffset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Debug::fmt(self, f) }
 }
-

--- a/src/offset/local.rs
+++ b/src/offset/local.rs
@@ -60,6 +60,7 @@ fn datetime_to_timespec(d: &NaiveDateTime, local: bool) -> stdtime::Timespec {
 /// The local timescale. This is implemented via the standard `time` crate.
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Local;
 
 impl Local {
@@ -116,4 +117,3 @@ impl TimeZone for Local {
         tm_to_datetime(stdtime::at(timespec))
     }
 }
-

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -31,6 +31,9 @@ use date::Date;
 use datetime::DateTime;
 use format::{parse, Parsed, ParseResult, StrftimeItems};
 
+#[cfg(feature = "serde_support")]
+use serde::{Serialize, Deserialize};
+
 /// The conversion result from the local time to the timezone-aware datetime types.
 #[derive(Clone, PartialEq, Debug)]
 pub enum LocalResult<T> {
@@ -157,8 +160,16 @@ impl<T: fmt::Debug> LocalResult<T> {
     }
 }
 
+#[cfg(not(feature = "serde_support"))]
 /// The offset from the local time to UTC.
 pub trait Offset: Sized + Clone + fmt::Debug {
+    /// Returns the offset from UTC to the local time stored.
+    fn local_minus_utc(&self) -> Duration;
+}
+
+#[cfg(feature = "serde_support")]
+/// The offset from the local time to UTC.
+pub trait Offset: Sized + Clone + fmt::Debug + Serialize + Deserialize {
     /// Returns the offset from UTC to the local time stored.
     fn local_minus_utc(&self) -> Duration;
 }
@@ -331,4 +342,3 @@ pub trait TimeZone: Sized + Clone {
 pub mod utc;
 pub mod fixed;
 pub mod local;
-

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -20,6 +20,7 @@ use super::{TimeZone, Offset, LocalResult};
 /// It is also used as an offset (which is also a dummy type).
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct UTC;
 
 impl UTC {
@@ -61,4 +62,3 @@ impl fmt::Debug for UTC {
 impl fmt::Display for UTC {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "UTC") }
 }
-


### PR DESCRIPTION
Adds optional serializaiton support through serde, basically mimicking rustc-serialization added in #36.  

Requires the nightly version of serde (e.g. compiler plugins and macros) instead of the stable version.  The stable version was just too invasive to easily add to Chrono without a lot of changes.

Because cargo cannot have a feature and a dependency groups share the same name, the feature for this is called "serde_support" instead of "serde".

Sorry about all the trailing new lines being removed in the diffs, not sure why Atom decided to eat those.  Lemme know and I can fix those if you want.