### PR TITLE
Added serde support for DateTime, NaiveDate, NaiveTime and NaiveDateTime.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ env:
 script:
   - cargo build -v
   - cargo build -v --features rustc-serialize
+  - cargo build -v --features serde
   - cargo test -v
   - cargo test -v --features rustc-serialize
+  - cargo test -v --features serde
   - cargo doc
 after_script:
   - cd target && curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,7 @@ name = "chrono"
 time = "*"
 num = "*"
 rustc-serialize = { version = "0.3", optional = true }
+serde = { version = "^0.6.0", optional = true }
 
+[dev-dependencies]
+serde_json = { version = "^0.6.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,6 +275,8 @@ extern crate time as stdtime;
 extern crate num;
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
+#[cfg(feature = "serde")]
+extern crate serde;
 
 pub use duration::Duration;
 pub use offset::{TimeZone, Offset, LocalResult};


### PR DESCRIPTION
I tried to take a stab at adding serde support as it seems as if the other attempt was abandoned. This one uses debug formatting for serialization and parse (FromStr) for deserialization. It also works in Rust stable.