### PR TITLE
make ParseErrorKind public

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -184,7 +184,7 @@ macro_rules! fix  { ($x:ident) => (Item::Fixed(Fixed::$x)) }
 pub struct ParseError(ParseErrorKind);
 
 #[derive(Debug, Clone, PartialEq, Copy)]
-enum ParseErrorKind {
+pub enum ParseErrorKind {
     /// Given field is out of permitted range.
     OutOfRange,
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -183,6 +183,7 @@ macro_rules! fix  { ($x:ident) => (Item::Fixed(Fixed::$x)) }
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub struct ParseError(ParseErrorKind);
 
+/// Details of the `ParseError` returned by the `parse` function.
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum ParseErrorKind {
     /// Given field is out of permitted range.


### PR DESCRIPTION
It'd be nice to be able to run a match over the ParseError returned from an attempted parse. Making the ParseErrorKind public means you can match `ParseError(ParseErrorKind::NotEnough))` for example.