### PR TITLE
Don't depend on num's default features; removing rand requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "chrono"
 
 [dependencies]
 time = "0.1"
-num = "0.1"
+num = { version = "0.1", default-features = false }
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "^0.6.0", optional = true }
 


### PR DESCRIPTION
requirement for `rand` comes from `num`'s default features which are all unused in `chrono`
not including the default features means that that `build` no longer requires `rand` (and hence does not pass it on to others importing `chrono`)

Not quite sure why `cargo test` still wants rand, but it's to do with the `serde_json` dev-dependency