### PR TITLE
Added w3c support.

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -144,6 +144,25 @@ impl DateTime<FixedOffset> {
         parsed.to_datetime()
     }
 
+    /// Parses an W3C date and time string then returns a new `DateTime` with a parsed `FixedOffset`.
+    ///
+    /// W3C note: https://www.w3.org/TR/NOTE-datetime
+    ///
+    /// Valid formats: `YYYY-MM-DD`, 
+    /// `YYYY-MM-DDThh:mmTZD`, 
+    /// `YYYY-MM-DDThh:mm:ssTZD`, 
+    /// `YYYY-MM-DDThh:mm:ss.sTZD`
+    ///
+    /// Invalid formats: 
+    /// `YYYY`,
+    /// `YYYY-MM`
+    pub fn parse_from_w3c(s: &str) -> ParseResult<DateTime<FixedOffset>> {
+        const ITEMS: &'static [Item<'static>] = &[Item::Fixed(Fixed::W3C)];
+        let mut parsed = Parsed::new();
+        try!(parse(&mut parsed, s, ITEMS.iter().cloned()));
+        parsed.to_w3c_datetime()
+    }
+
     /// Parses a string with the specified format string and
     /// returns a new `DateTime` with a parsed `FixedOffset`.
     /// See the [`format::strftime` module](../format/strftime/index.html)
@@ -167,6 +186,12 @@ impl<Tz: TimeZone> DateTime<Tz> where Tz::Offset: fmt::Display {
     /// Returns an RFC 3339 and ISO 8601 date and time string such as `1996-12-19T16:39:57-08:00`.
     pub fn to_rfc3339(&self) -> String {
         const ITEMS: &'static [Item<'static>] = &[Item::Fixed(Fixed::RFC3339)];
+        self.format_with_items(ITEMS.iter().cloned()).to_string()
+    }
+
+    /// Returns an W3C date and time string such as `1996-12-19T16:39:57Z`.
+    pub fn to_w3c(&self) -> String {
+        const ITEMS: &'static [Item<'static>] = &[Item::Fixed(Fixed::W3C)];
         self.format_with_items(ITEMS.iter().cloned()).to_string()
     }
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -154,6 +154,8 @@ pub enum Fixed {
     RFC2822,
     /// RFC 3339 & ISO 8601 date and time syntax.
     RFC3339,
+    /// W3C date and time syntax.
+    W3C
 }
 
 /// A single formatting item. This is used for both formatting and parsing.
@@ -429,6 +431,14 @@ pub fn format<'a, I>(w: &mut fmt::Formatter, date: Option<&NaiveDate>, time: Opt
                         } else {
                             None
                         },
+                    W3C => if let (Some(d), Some(t), Some(&(_, off))) = (date, time, off) {
+                            // reuse `Debug` impls which already print ISO 8601 format.
+                            // this is faster in this way.
+                            try!(write!(w, "{:?}T{:?}", d, t));
+                            Some(write_local_minus_utc(w, off, true, true))
+                        } else {
+                            None
+                        }, 
                 };
 
                 match ret {


### PR DESCRIPTION
It's may parse these formats:
- YYYY-MM-DD
- YYYY-MM-DDThh:mmTZD
- YYYY-MM-DDThh:mm:ssTZD
- YYYY-MM-DDThh:mm:ss.sTZD

These formats are not supported:
- YYYY
- YYYY-MM

Added functions:
- format::parse::parse_w3c<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult<(&'a str, ())>
- datetime::DateTime::parse_from_w3c(s: &str) -> ParseResult<DateTime<FixedOffset>>
- datetime::DateTime::to_w3c(&self) -> String
- format::parsed::Parsed::to_w3c_datetime(&self) -> ParseResult<DateTime<FixedOffset>>

Added unit-tests:
- test_w3c
