### PR TITLE
Fix parsing LongWeekday when day is Sunday

### DIFF
--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -652,6 +652,21 @@ fn parse_rfc850() {
 
     // Check that it parses correctly
     assert_eq!(Ok(dt), UTC.datetime_from_str("Sunday, 06-Nov-94 08:49:37 GMT", RFC850_FMT));
+
+    // Check that the rest of the weekdays parse correctly (this test originally failed because
+    // Sunday parsed incorrectly).
+    let testdates = [
+        (UTC.ymd(1994, 11, 7).and_hms(8, 49, 37),  "Monday, 07-Nov-94 08:49:37 GMT"),
+        (UTC.ymd(1994, 11, 8).and_hms(8, 49, 37),  "Tuesday, 08-Nov-94 08:49:37 GMT"),
+        (UTC.ymd(1994, 11, 9).and_hms(8, 49, 37),  "Wednesday, 09-Nov-94 08:49:37 GMT"),
+        (UTC.ymd(1994, 11, 10).and_hms(8, 49, 37), "Thursday, 10-Nov-94 08:49:37 GMT"),
+        (UTC.ymd(1994, 11, 11).and_hms(8, 49, 37), "Friday, 11-Nov-94 08:49:37 GMT"),
+        (UTC.ymd(1994, 11, 12).and_hms(8, 49, 37), "Saturday, 12-Nov-94 08:49:37 GMT"),
+    ];
+
+    for val in &testdates {
+        assert_eq!(Ok(val.0), UTC.datetime_from_str(val.1, RFC850_FMT));
+    }
 }
 
 #[cfg(test)]

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -635,6 +635,25 @@ fn test_rfc2822() {
     };
 }
 
+
+
+#[cfg(test)]
+#[test]
+fn parse_rfc850() {
+    use ::{UTC, TimeZone};
+
+    static RFC850_FMT: &'static str =  "%A, %d-%b-%y %T GMT";
+
+    let dt_str = "Sunday, 06-Nov-94 08:49:37 GMT";
+    let dt = UTC.ymd(1994, 11, 6).and_hms(8, 49, 37);
+
+    // Check that the format is what we expect
+    assert_eq!(dt.format(RFC850_FMT).to_string(), dt_str);
+
+    // Check that it parses correctly
+    assert_eq!(Ok(dt), UTC.datetime_from_str("Sunday, 06-Nov-94 08:49:37 GMT", RFC850_FMT));
+}
+
 #[cfg(test)]
 #[test]
 fn test_rfc3339() {

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -128,7 +128,7 @@ pub fn short_or_long_month0(s: &str) -> ParseResult<(&str, u8)> {
 pub fn short_or_long_weekday(s: &str) -> ParseResult<(&str, Weekday)> {
     // lowercased weekday names, minus first three chars
     static LONG_WEEKDAY_SUFFIXES: [&'static str; 7] =
-        ["day", "sday", "nesday", "rsday", "day", "urday", "sunday"];
+        ["day", "sday", "nesday", "rsday", "day", "urday", "day"];
 
     let (mut s, weekday) = try!(short_weekday(s));
 


### PR DESCRIPTION
I was working on parsing the `HTTP-date` format, and I discovered that the RFC850 variant was failing to parse! It turned out that this was an issue parsing Sunday at the front of the string. There's now a test that covers each day of the week. The test doubles as verification that chrono can parse RFC850 using the public API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lifthrasiir/rust-chrono/66)
<!-- Reviewable:end -->
