### PR TITLE
Clean up Duration intro doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ extern crate chrono;
 
 ### Duration
 
-Chrono used to have a `Duration` type, which represents the time span.
-This is a simple reexport of
-[`time::Duration`](http://doc.rust-lang.org/time/time/struct.Duration.html) type
-provided by crates.io `time` crate (which originally comes from Chrono).
+[`chrono::Duration`](https://lifthrasiir.github.io/rust-chrono/chrono/struct.Duration.html)
+represents the magnitude of a time span. `Duration` used to be provided by Chrono. 
+It has been moved to the `time` crate as the
+[`time::Duration`](http://doc.rust-lang.org/time/time/struct.Duration.html) type, but is
+still re-exported from Chrono.
 
 ### Date and Time
 


### PR DESCRIPTION
• Make a Duration description the first thing mentioned instead of project history.
• Add "magnitude" to the description to disambiguate it from Interval (in the Joda sense).
• Brush up some awkward language.
• Add a doc link and illustrate the module namespace.