### PR TITLE
Add functions to get milli/micro/nano-seconds from a DateTime

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -60,6 +60,30 @@ impl<Tz: TimeZone> DateTime<Tz> {
         self.datetime.timestamp()
     }
 
+    /// Returns the number of milliseconds since the last second boundary
+    ///
+    /// note: this is not the number of milliseconds since January 1, 1970 0:00:00 UTC
+    #[inline]
+    pub fn timestamp_milliseconds_part(&self) -> u32 {
+        self.datetime.timestamp_milliseconds_part()
+    }
+
+    /// Returns the number of microseconds since the last second boundary
+    ///
+    /// note: this is not the number of microseconds since January 1, 1970 0:00:00 UTC
+    #[inline]
+    pub fn timestamp_microseconds_part(&self) -> u32 {
+        self.datetime.timestamp_microseconds_part()
+    }
+
+    /// Returns the number of nanoseconds since the last second boundary
+    ///
+    /// note: this is not the number of nanoseconds since January 1, 1970 0:00:00 UTC
+    #[inline]
+    pub fn timestamp_nanoseconds_part(&self) -> u32 {
+        self.datetime.timestamp_nanoseconds_part()
+    }
+
     /// *Deprecated*: Same to `DateTime::timestamp`.
     #[inline]
     pub fn num_seconds_from_unix_epoch(&self) -> i64 {
@@ -386,7 +410,7 @@ mod serde {
             serializer.serialize_str(&format!("{:?}", self))
         }
     }
-    
+
     struct DateTimeVisitor;
     
     impl de::Visitor for DateTimeVisitor {
@@ -398,7 +422,7 @@ mod serde {
             value.parse().map_err(|err| E::custom(format!("{}", err)))
         }
     }
-    
+
     impl de::Deserialize for DateTime<FixedOffset> {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
@@ -406,7 +430,7 @@ mod serde {
             deserializer.deserialize(DateTimeVisitor)
         }
     }
-    
+
     impl de::Deserialize for DateTime<UTC> {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
@@ -414,7 +438,7 @@ mod serde {
             deserializer.deserialize(DateTimeVisitor).map(|dt| dt.with_timezone(&UTC))
         }
     }
-    
+
     impl de::Deserialize for DateTime<Local> {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
@@ -603,22 +627,31 @@ mod tests {
     #[test]
     fn test_serde_serialize() {
         use self::serde_json::to_string;
-        
+
         let date = UTC.ymd(2014, 7, 24).and_hms(12, 34, 6);
         let serialized = to_string(&date).unwrap();
 
         assert_eq!(serialized, "\"2014-07-24T12:34:06Z\"");
     }
-    
+
     #[cfg(feature = "serde")]
     #[test]
     fn test_serde_deserialize() {
         use self::serde_json::from_str;
-        
+
         let date = UTC.ymd(2014, 7, 24).and_hms(12, 34, 6);
         let deserialized: DateTime<UTC> = from_str("\"2014-07-24T12:34:06Z\"").unwrap();
 
         assert_eq!(deserialized, date);
     }
-}
 
+    #[test]
+    fn test_subsecond_part() {
+        let datetime = UTC.ymd(2014, 7, 8).and_hms_nano(9, 10, 11, 1234567);
+
+        assert_eq!(1,       datetime.timestamp_milliseconds_part());
+        assert_eq!(1234,    datetime.timestamp_microseconds_part());
+        assert_eq!(1234567, datetime.timestamp_nanoseconds_part());
+    }
+
+}

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -62,26 +62,32 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Returns the number of milliseconds since the last second boundary
     ///
+    /// warning: in event of a leap second, this may exceed 999
+    ///
     /// note: this is not the number of milliseconds since January 1, 1970 0:00:00 UTC
     #[inline]
-    pub fn timestamp_milliseconds_part(&self) -> u32 {
-        self.datetime.timestamp_milliseconds_part()
+    pub fn timestamp_subsec_millis(&self) -> u32 {
+        self.datetime.timestamp_subsec_millis()
     }
 
     /// Returns the number of microseconds since the last second boundary
     ///
+    /// warning: in event of a leap second, this may exceed 999_999
+    ///
     /// note: this is not the number of microseconds since January 1, 1970 0:00:00 UTC
     #[inline]
-    pub fn timestamp_microseconds_part(&self) -> u32 {
-        self.datetime.timestamp_microseconds_part()
+    pub fn timestamp_subsec_micros(&self) -> u32 {
+        self.datetime.timestamp_subsec_micros()
     }
 
     /// Returns the number of nanoseconds since the last second boundary
     ///
+    /// warning: in event of a leap second, this may exceed 999_999_999
+    ///
     /// note: this is not the number of nanoseconds since January 1, 1970 0:00:00 UTC
     #[inline]
-    pub fn timestamp_nanoseconds_part(&self) -> u32 {
-        self.datetime.timestamp_nanoseconds_part()
+    pub fn timestamp_subsec_nanos(&self) -> u32 {
+        self.datetime.timestamp_subsec_nanos()
     }
 
     /// *Deprecated*: Same to `DateTime::timestamp`.
@@ -410,7 +416,7 @@ mod serde {
             serializer.serialize_str(&format!("{:?}", self))
         }
     }
-
+    
     struct DateTimeVisitor;
     
     impl de::Visitor for DateTimeVisitor {
@@ -422,7 +428,7 @@ mod serde {
             value.parse().map_err(|err| E::custom(format!("{}", err)))
         }
     }
-
+    
     impl de::Deserialize for DateTime<FixedOffset> {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
@@ -430,7 +436,7 @@ mod serde {
             deserializer.deserialize(DateTimeVisitor)
         }
     }
-
+    
     impl de::Deserialize for DateTime<UTC> {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
@@ -438,7 +444,7 @@ mod serde {
             deserializer.deserialize(DateTimeVisitor).map(|dt| dt.with_timezone(&UTC))
         }
     }
-
+    
     impl de::Deserialize for DateTime<Local> {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
@@ -627,18 +633,18 @@ mod tests {
     #[test]
     fn test_serde_serialize() {
         use self::serde_json::to_string;
-
+        
         let date = UTC.ymd(2014, 7, 24).and_hms(12, 34, 6);
         let serialized = to_string(&date).unwrap();
 
         assert_eq!(serialized, "\"2014-07-24T12:34:06Z\"");
     }
-
+    
     #[cfg(feature = "serde")]
     #[test]
     fn test_serde_deserialize() {
         use self::serde_json::from_str;
-
+        
         let date = UTC.ymd(2014, 7, 24).and_hms(12, 34, 6);
         let deserialized: DateTime<UTC> = from_str("\"2014-07-24T12:34:06Z\"").unwrap();
 
@@ -649,9 +655,9 @@ mod tests {
     fn test_subsecond_part() {
         let datetime = UTC.ymd(2014, 7, 8).and_hms_nano(9, 10, 11, 1234567);
 
-        assert_eq!(1,       datetime.timestamp_milliseconds_part());
-        assert_eq!(1234,    datetime.timestamp_microseconds_part());
-        assert_eq!(1234567, datetime.timestamp_nanoseconds_part());
+        assert_eq!(1,       datetime.timestamp_subsec_millis());
+        assert_eq!(1234,    datetime.timestamp_subsec_micros());
+        assert_eq!(1234567, datetime.timestamp_subsec_nanos());
     }
 
 }

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -105,6 +105,30 @@ impl NaiveDateTime {
         (ndays - 719163) * 86400 + nseconds
     }
 
+    /// Returns the number of milliseconds since the last second boundary
+    ///
+    /// note: this is not the number of milliseconds since January 1, 1970 0:00:00 UTC
+    #[inline]
+    pub fn timestamp_milliseconds_part(&self) -> u32 {
+        self.timestamp_nanoseconds_part() / 1_000_000
+    }
+
+    /// Returns the number of microseconds since the last second boundary
+    ///
+    /// note: this is not the number of microseconds since January 1, 1970 0:00:00 UTC
+    #[inline]
+    pub fn timestamp_microseconds_part(&self) -> u32 {
+        self.timestamp_nanoseconds_part() / 1_000
+    }
+
+    /// Returns the number of nanoseconds since the last second boundary
+    ///
+    /// note: this is not the number of nanoseconds since January 1, 1970 0:00:00 UTC
+    #[inline]
+    pub fn timestamp_nanoseconds_part(&self) -> u32 {
+        self.time.nanosecond()
+    }
+
     /// *Deprecated:* Same to `NaiveDateTime::timestamp`.
     #[inline]
     pub fn num_seconds_from_unix_epoch(&self) -> i64 {
@@ -327,9 +351,9 @@ mod serde {
             serializer.serialize_str(&format!("{:?}", self))
         }
     }
-    
+
     struct NaiveDateTimeVisitor;
-    
+
     impl de::Visitor for NaiveDateTimeVisitor {
         type Value = NaiveDateTime;
 
@@ -339,7 +363,7 @@ mod serde {
             value.parse().map_err(|err| E::custom(format!("{}", err)))
         }
     }
-    
+
     impl de::Deserialize for NaiveDateTime {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
@@ -510,22 +534,21 @@ mod tests {
     #[test]
     fn test_serde_serialize() {
         use self::serde_json::to_string;
-        
+
         let date = NaiveDate::from_ymd(2014, 7, 24).and_hms(12, 34, 6);
         let serialized = to_string(&date).unwrap();
 
         assert_eq!(serialized, "\"2014-07-24T12:34:06\"");
     }
-    
+
     #[cfg(feature = "serde")]
     #[test]
     fn test_serde_deserialize() {
         use self::serde_json::from_str;
-        
+
         let date = NaiveDate::from_ymd(2014, 7, 24).and_hms(12, 34, 6);
         let deserialized: NaiveDateTime = from_str("\"2014-07-24T12:34:06\"").unwrap();
 
         assert_eq!(deserialized, date);
     }
 }
-

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -107,25 +107,31 @@ impl NaiveDateTime {
 
     /// Returns the number of milliseconds since the last second boundary
     ///
+    /// warning: in event of a leap second, this may exceed 999
+    ///
     /// note: this is not the number of milliseconds since January 1, 1970 0:00:00 UTC
     #[inline]
-    pub fn timestamp_milliseconds_part(&self) -> u32 {
-        self.timestamp_nanoseconds_part() / 1_000_000
+    pub fn timestamp_subsec_millis(&self) -> u32 {
+        self.timestamp_subsec_nanos() / 1_000_000
     }
 
     /// Returns the number of microseconds since the last second boundary
     ///
+    /// warning: in event of a leap second, this may exceed 999_999
+    ///
     /// note: this is not the number of microseconds since January 1, 1970 0:00:00 UTC
     #[inline]
-    pub fn timestamp_microseconds_part(&self) -> u32 {
-        self.timestamp_nanoseconds_part() / 1_000
+    pub fn timestamp_subsec_micros(&self) -> u32 {
+        self.timestamp_subsec_nanos() / 1_000
     }
 
     /// Returns the number of nanoseconds since the last second boundary
     ///
+    /// warning: in event of a leap second, this may exceed 999_999_999
+    ///
     /// note: this is not the number of nanoseconds since January 1, 1970 0:00:00 UTC
     #[inline]
-    pub fn timestamp_nanoseconds_part(&self) -> u32 {
+    pub fn timestamp_subsec_nanos(&self) -> u32 {
         self.time.nanosecond()
     }
 
@@ -351,9 +357,9 @@ mod serde {
             serializer.serialize_str(&format!("{:?}", self))
         }
     }
-
+    
     struct NaiveDateTimeVisitor;
-
+    
     impl de::Visitor for NaiveDateTimeVisitor {
         type Value = NaiveDateTime;
 
@@ -363,7 +369,7 @@ mod serde {
             value.parse().map_err(|err| E::custom(format!("{}", err)))
         }
     }
-
+    
     impl de::Deserialize for NaiveDateTime {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
@@ -534,18 +540,18 @@ mod tests {
     #[test]
     fn test_serde_serialize() {
         use self::serde_json::to_string;
-
+        
         let date = NaiveDate::from_ymd(2014, 7, 24).and_hms(12, 34, 6);
         let serialized = to_string(&date).unwrap();
 
         assert_eq!(serialized, "\"2014-07-24T12:34:06\"");
     }
-
+    
     #[cfg(feature = "serde")]
     #[test]
     fn test_serde_deserialize() {
         use self::serde_json::from_str;
-
+        
         let date = NaiveDate::from_ymd(2014, 7, 24).and_hms(12, 34, 6);
         let deserialized: NaiveDateTime = from_str("\"2014-07-24T12:34:06\"").unwrap();
 


### PR DESCRIPTION
Using the underlying naive::NaiveTime fractional part, we compute
the number of milli/micro/nano-seconds since the last second boundary.

The reason for not computing elapsed time since 1970 is because we
would hit potential issues of i64s not being large enough (the range
would be strictly smaller than the 64bit-timestamp range, causing
compatibility issues).

This was written in response to issue #74.