### PR TITLE
Update serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "chrono"
 time = "0.1"
 num = { version = "0.1", default-features = false }
 rustc-serialize = { version = "0.3", optional = true }
-serde = { version = "^0.7.0", optional = true }
+serde = { version = "<0.9", optional = true }
 
 [dev-dependencies]
-serde_json = { version = "^0.7.0" }
+serde_json = { version = ">=0.7.0" }


### PR DESCRIPTION
Well, `chrono` also works with older versions of `serde`, so I decided to use `<0.9` as version bound