### PR TITLE
Support deserializing from bincode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ serde = { version = "<0.9", optional = true }
 
 [dev-dependencies]
 serde_json = { version = ">=0.7.0" }
+bincode = { version = "0.6", features = ["serde"], default-features = false }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -496,7 +496,7 @@ mod serde {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
         {
-            deserializer.deserialize(DateTimeVisitor)
+            deserializer.deserialize_str(DateTimeVisitor)
         }
     }
 
@@ -504,7 +504,7 @@ mod serde {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
         {
-            deserializer.deserialize(DateTimeVisitor).map(|dt| dt.with_timezone(&UTC))
+            deserializer.deserialize_str(DateTimeVisitor).map(|dt| dt.with_timezone(&UTC))
         }
     }
 
@@ -512,7 +512,7 @@ mod serde {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
         {
-            deserializer.deserialize(DateTimeVisitor).map(|dt| dt.with_timezone(&Local))
+            deserializer.deserialize_str(DateTimeVisitor).map(|dt| dt.with_timezone(&Local))
         }
     }
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -517,6 +517,7 @@ mod serde {
     }
 
     #[cfg(test)] extern crate serde_json;
+    #[cfg(test)] extern crate bincode;
 
     #[test]
     fn test_serde_serialize() {
@@ -536,6 +537,20 @@ mod serde {
                    Some(UTC.ymd(2014, 7, 24).and_hms(12, 34, 6)));
 
         assert!(from_str(r#""2014-07-32T12:34:06Z""#).is_err());
+    }
+
+    #[test]
+    fn test_serde_bincode() {
+        // Bincode is relevant to test separately from JSON because
+        // it is not self-describing.
+        use self::bincode::SizeLimit;
+        use self::bincode::serde::{serialize, deserialize};
+
+        let dt = UTC.ymd(2014, 7, 24).and_hms(12, 34, 6);
+        let encoded = serialize(&dt, SizeLimit::Infinite).unwrap();
+        let decoded: DateTime<UTC> = deserialize(&encoded).unwrap();
+        assert_eq!(dt, decoded);
+        assert_eq!(dt.offset(), decoded.offset());
     }
 }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1586,6 +1586,7 @@ mod serde {
     }
 
     #[cfg(test)] extern crate serde_json;
+    #[cfg(test)] extern crate bincode;
 
     #[test]
     fn test_serde_serialize() {
@@ -1636,6 +1637,19 @@ mod serde {
         assert!(from_str(r#"{}"#).is_err());
         assert!(from_str(r#"{"ymdf":20}"#).is_err()); // :(
         assert!(from_str(r#"null"#).is_err());
+    }
+
+    #[test]
+    fn test_serde_bincode() {
+        // Bincode is relevant to test separately from JSON because
+        // it is not self-describing.
+        use self::bincode::SizeLimit;
+        use self::bincode::serde::{serialize, deserialize};
+
+        let d = NaiveDate::from_ymd(2014, 7, 24);
+        let encoded = serialize(&d, SizeLimit::Infinite).unwrap();
+        let decoded: NaiveDate = deserialize(&encoded).unwrap();
+        assert_eq!(d, decoded);
     }
 }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1581,7 +1581,7 @@ mod serde {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
         {
-            deserializer.deserialize(NaiveDateVisitor)
+            deserializer.deserialize_str(NaiveDateVisitor)
         }
     }
 

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1143,7 +1143,7 @@ mod serde {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
         {
-            deserializer.deserialize(NaiveDateTimeVisitor)
+            deserializer.deserialize_str(NaiveDateTimeVisitor)
         }
     }
 

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1148,6 +1148,7 @@ mod serde {
     }
 
     #[cfg(test)] extern crate serde_json;
+    #[cfg(test)] extern crate bincode;
 
     #[test]
     fn test_serde_serialize() {
@@ -1229,6 +1230,20 @@ mod serde {
         assert!(from_str(r#"{}"#).is_err());
         assert!(from_str(r#"{"date":{"ymdf":20},"time":{"secs":0,"frac":0}}"#).is_err()); // :(
         assert!(from_str(r#"null"#).is_err());
+    }
+
+    #[test]
+    fn test_serde_bincode() {
+        // Bincode is relevant to test separately from JSON because
+        // it is not self-describing.
+        use naive::date::NaiveDate;
+        use self::bincode::SizeLimit;
+        use self::bincode::serde::{serialize, deserialize};
+
+        let dt = NaiveDate::from_ymd(2016, 7, 8).and_hms_milli(9, 10, 48, 90);
+        let encoded = serialize(&dt, SizeLimit::Infinite).unwrap();
+        let decoded: NaiveDateTime = deserialize(&encoded).unwrap();
+        assert_eq!(dt, decoded);
     }
 }
 

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -1273,6 +1273,7 @@ mod serde {
     }
 
     #[cfg(test)] extern crate serde_json;
+    #[cfg(test)] extern crate bincode;
 
     #[test]
     fn test_serde_serialize() {
@@ -1339,6 +1340,19 @@ mod serde {
         assert!(from_str(r#"{}"#).is_err());
         assert!(from_str(r#"{"secs":0,"frac":0}"#).is_err()); // :(
         assert!(from_str(r#"null"#).is_err());
+    }
+
+    #[test]
+    fn test_serde_bincode() {
+        // Bincode is relevant to test separately from JSON because
+        // it is not self-describing.
+        use self::bincode::SizeLimit;
+        use self::bincode::serde::{serialize, deserialize};
+
+        let t = NaiveTime::from_hms_nano(3, 5, 7, 98765432);
+        let encoded = serialize(&t, SizeLimit::Infinite).unwrap();
+        let decoded: NaiveTime = deserialize(&encoded).unwrap();
+        assert_eq!(t, decoded);
     }
 }
 

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -1268,7 +1268,7 @@ mod serde {
         fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
             where D: de::Deserializer
         {
-            deserializer.deserialize(NaiveTimeVisitor)
+            deserializer.deserialize_str(NaiveTimeVisitor)
         }
     }
 


### PR DESCRIPTION
Bincode is a minimal format that expects the Deserialize implementation to tell it what type of data it should expect to see.

Fixes https://github.com/TyOverby/bincode/issues/85.