### PR TITLE
Add support for assignment operators. Fixes #70

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -8,7 +8,7 @@
 
 use std::{fmt, hash};
 use std::cmp::Ordering;
-use std::ops::{Add, Sub};
+use std::ops::{Add, Sub, AddAssign, SubAssign};
 
 use {Weekday, Datelike};
 use duration::Duration;
@@ -341,6 +341,12 @@ impl<Tz: TimeZone> Add<Duration> for Date<Tz> {
     }
 }
 
+impl<Tz: TimeZone> AddAssign<Duration> for Date<Tz> {
+    fn add_assign(&mut self, rhs: Duration) {
+        *self = self.clone().add(rhs);
+    }
+}
+
 impl<Tz: TimeZone, Tz2: TimeZone> Sub<Date<Tz2>> for Date<Tz> {
     type Output = Duration;
 
@@ -354,6 +360,12 @@ impl<Tz: TimeZone> Sub<Duration> for Date<Tz> {
     #[inline]
     fn sub(self, rhs: Duration) -> Date<Tz> {
         self.checked_sub(rhs).expect("`Date - Duration` overflowed")
+    }
+}
+
+impl<Tz: TimeZone> SubAssign<Duration> for Date<Tz> {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = self.clone().sub(rhs);
     }
 }
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -8,7 +8,7 @@
 
 use std::{str, fmt, hash};
 use std::cmp::Ordering;
-use std::ops::{Add, Sub};
+use std::ops::{Add, Sub, AddAssign, SubAssign};
 
 use {Weekday, Timelike, Datelike};
 use offset::{TimeZone, Offset, add_with_leapsecond};
@@ -324,6 +324,12 @@ impl<Tz: TimeZone> Add<Duration> for DateTime<Tz> {
     }
 }
 
+impl<Tz: TimeZone> AddAssign<Duration> for DateTime<Tz> {
+    fn add_assign(&mut self, rhs: Duration) {
+        *self = self.clone().add(rhs);
+    }
+}
+
 impl<Tz: TimeZone, Tz2: TimeZone> Sub<DateTime<Tz2>> for DateTime<Tz> {
     type Output = Duration;
 
@@ -337,6 +343,12 @@ impl<Tz: TimeZone> Sub<Duration> for DateTime<Tz> {
     #[inline]
     fn sub(self, rhs: Duration) -> DateTime<Tz> {
         self.checked_sub(rhs).expect("`DateTime - Duration` overflowed")
+    }
+}
+
+impl<Tz: TimeZone> SubAssign<Duration> for DateTime<Tz> {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = self.clone().sub(rhs);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,12 @@
 //!            UTC.ymd(2001, 9, 9).and_hms(1, 46, 40));
 //! assert_eq!(UTC.ymd(1970, 1, 1).and_hms(0, 0, 0) - Duration::seconds(1_000_000_000),
 //!            UTC.ymd(1938, 4, 24).and_hms(22, 13, 20));
+//!
+//! // assignment operators
+//! let mut date = UTC.ymd(1970, 1, 1).and_hms(0, 0, 0);
+//! date += Duration::seconds(1_000_000_000);
+//! date -= Duration::seconds(999_999_999);
+//! assert_eq!(date, UTC.ymd(1970, 1, 1).and_hms(0, 0, 1));
 //! ~~~~
 //!
 //! Formatting is done via the [`format`](./datetime/struct.DateTime.html#method.format) method,

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -48,7 +48,7 @@
 //! This is currently the internal format of Chrono's date types.
 
 use std::{str, fmt, hash};
-use std::ops::{Add, Sub};
+use std::ops::{Add, Sub, AddAssign, SubAssign};
 use num::traits::ToPrimitive;
 
 use {Weekday, Datelike};
@@ -1318,6 +1318,12 @@ impl Add<Duration> for NaiveDate {
     }
 }
 
+impl AddAssign<Duration> for NaiveDate {
+    fn add_assign(&mut self, rhs: Duration) {
+        self.add(rhs);
+    }
+}
+
 /// A subtraction of `NaiveDate` from `NaiveDate` yields a `Duration` of integral numbers.
 ///
 /// This does not overflow or underflow at all,
@@ -1383,6 +1389,13 @@ impl Sub<Duration> for NaiveDate {
         self.checked_sub(rhs).expect("`NaiveDate - Duration` overflowed")
     }
 }
+
+impl SubAssign<Duration> for NaiveDate {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = self.sub(rhs);
+    }
+}
+
 
 /// The `Debug` output of the naive date `d` is same to
 /// [`d.format("%Y-%m-%d")`](../../format/strftime/index.html).

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -5,7 +5,7 @@
 //! ISO 8601 date and time without timezone.
 
 use std::{str, fmt, hash};
-use std::ops::{Add, Sub};
+use std::ops::{Add, Sub, AddAssign, SubAssign};
 use num::traits::ToPrimitive;
 
 use {Weekday, Timelike, Datelike};
@@ -1101,6 +1101,13 @@ impl Add<Duration> for NaiveDateTime {
     }
 }
 
+impl AddAssign<Duration> for NaiveDateTime {
+    fn add_assign(&mut self, rhs: Duration) {
+        self.add(rhs);
+    }
+}
+
+
 /// A subtraction of `NaiveDateTime` from `NaiveDateTime` yields a `Duration`.
 /// This does not overflow or underflow at all.
 ///
@@ -1201,6 +1208,12 @@ impl Sub<Duration> for NaiveDateTime {
     #[inline]
     fn sub(self, rhs: Duration) -> NaiveDateTime {
         self.checked_sub(rhs).expect("`NaiveDateTime - Duration` overflowed")
+    }
+}
+
+impl SubAssign<Duration> for NaiveDateTime {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = self.sub(rhs);
     }
 }
 

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -158,7 +158,7 @@
 //! **there is absolutely no guarantee that the leap second read has actually happened**.
 
 use std::{str, fmt, hash};
-use std::ops::{Add, Sub};
+use std::ops::{Add, Sub, AddAssign, SubAssign};
 
 use Timelike;
 use div::div_mod_floor;
@@ -972,6 +972,13 @@ impl Add<Duration> for NaiveTime {
     }
 }
 
+impl AddAssign<Duration> for NaiveTime {
+    fn add_assign(&mut self, rhs: Duration) {
+                self.add(rhs);
+    }
+}
+
+
 /// A subtraction of `NaiveTime` from `NaiveTime` yields a `Duration` within +/- 1 day.
 /// This does not overflow or underflow at all.
 ///
@@ -1092,6 +1099,12 @@ impl Sub<Duration> for NaiveTime {
     #[inline]
     fn sub(self, rhs: Duration) -> NaiveTime {
         self.overflowing_sub(rhs).0
+    }
+}
+
+impl SubAssign<Duration> for NaiveTime {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = self.sub(rhs);
     }
 }
 


### PR DESCRIPTION
Because the non-naive dates are non-copy and the Add/Sub trait is not implemented for references, a clone is needed on on the non-naive types because Add/Sub consumes the value.

Requires Rust 1.8 or higher.