### PR TITLE
Added #[derive(Hash)] for Weekday enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,7 @@ pub mod format;
 /// The order of the days of week depends on the context.
 /// (This is why this type does *not* implement `PartialOrd` or `Ord` traits.)
 /// One should prefer `*_from_monday` or `*_from_sunday` methods to get the correct result.
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub enum Weekday {
     /// Monday.


### PR DESCRIPTION
This is so it can at least be used in a HashSet, if not in a BTreeSet
because it does not impl Ord.