### PR TITLE
Update for serde 0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 rust:
   # 1.8.0 is the earliest known version that Cargo does work for the current crates.io-index repo.
   # probably older versions work, but we are forced to use this as the minimum for Cargo...
-  - 1.8.0
+  - 1.13.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ name = "chrono"
 time = "0.1"
 num = { version = "0.1", default-features = false }
 rustc-serialize = { version = "0.3", optional = true }
-serde = { version = "<0.9", optional = true }
+serde = { version = "0.9", optional = true }
 
 [dev-dependencies]
-serde_json = { version = ">=0.7.0" }
-bincode = { version = "0.6", features = ["serde"], default-features = false }
+serde_json = { version = ">=0.9.0" }
+bincode = { version = "1.0.0-alpha1", features = ["serde"], default-features = false }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - TARGET: 1.8.0-x86_64-pc-windows-gnu
+    - TARGET: 1.13.0-x86_64-pc-windows-gnu
     - TARGET: nightly-x86_64-pc-windows-msvc
     - TARGET: nightly-i686-pc-windows-msvc
     - TARGET: nightly-x86_64-pc-windows-gnu


### PR DESCRIPTION
This is a quick upgrade to `serde 0.9`. It depends on https://github.com/TyOverby/bincode/issues/92 ~~so I can't run tests yet~~.

Note: I've changed the version bound for `serde` to `^0.9` because it's not backwards compatible with previous versions.

CC: @lifthrasiir